### PR TITLE
윤인섭 / 240612 / 1152. 단어의 개수

### DIFF
--- a/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
+++ b/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
@@ -1,4 +1,16 @@
 package BOJ.구현.단어의_개수_1152.insub2004_240612;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public class Main {
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] str = br.readLine().trim().split(" ");
+
+        System.out.println(str.length);
+    }
 }

--- a/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
+++ b/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
@@ -9,8 +9,15 @@ public class Main {
 
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
-        String[] str = br.readLine().trim().split(" ");
+        String[] str = br.readLine().trim().split("\\s");
 
-        System.out.println(str.length);
+        int result = str.length;
+
+        if(str.length == 1 && !str[0].contains("\\w")) {
+            if(str[0].contains())
+            result = 0;
+        }
+
+        System.out.println(result);
     }
 }

--- a/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
+++ b/BOJ/구현/단어의_개수_1152/insub2004_240612/Main.java
@@ -13,9 +13,10 @@ public class Main {
 
         int result = str.length;
 
-        if(str.length == 1 && !str[0].contains("\\w")) {
-            if(str[0].contains())
-            result = 0;
+        if(str.length == 1) {
+            if(str[0].isEmpty()) {
+                result = 0;
+            }
         }
 
         System.out.println(result);

--- a/BOJ/구현/알파벳_찾기_10809/insub2004_240612/Main.java
+++ b/BOJ/구현/알파벳_찾기_10809/insub2004_240612/Main.java
@@ -1,4 +1,5 @@
 package BOJ.구현.알파벳_찾기_10809.insub2004_240612;
 
 public class Main {
+
 }


### PR DESCRIPTION
어려운 점
- 공백 하나인 경우를 고려하지 않음
- 단어 하나 + 공백 인 경우를 고려하지 않음

해결 방법
1. 문자열을 입력받는다.
2. 입력 받은 문자열의 맨 앞과 맨 뒤의 공백을 제거한다. (trim)
3. 공백을 기준으로 나눈 결과를 배열에 담는다. (split)
4. 만약 배열의 길이가 1일 때 조건을 추가한다. 
5. [0]의 내용이 비어있으면 result에 0을  할당한다. (isEmpty)

공부해야 할 것
- 정규표현식
- String의 contains 올바른 사용 방법
- String의 isEmpty와 isBlank의 차이점